### PR TITLE
chore: add ci/cd github actions workflows for validating module changes and creating releases

### DIFF
--- a/.github/workflows/semantic-releaser.yml
+++ b/.github/workflows/semantic-releaser.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**.tf'
+      - '!examples/**.tf'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        run: npx semantic-release

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -1,0 +1,77 @@
+name: static-checks
+
+on:
+  pull_request:
+
+jobs:
+  versionExtract:
+    name: Get min/max versions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Terraform min/max versions
+        id: minMax
+        uses: clowdhaus/terraform-min-max@main
+    outputs:
+      minVersion: ${{ steps.minMax.outputs.minVersion }}
+      maxVersion: ${{ steps.minMax.outputs.maxVersion }}
+
+  versionEvaluate:
+    name: Evaluate Terraform versions
+    runs-on: ubuntu-latest
+    needs: versionExtract
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - ${{ needs.versionExtract.outputs.minVersion }}
+          - ${{ needs.versionExtract.outputs.maxVersion }}
+        directory:
+          - examples/mysql_iam_cluster
+          - examples/mysql_iam_instance
+          - examples/postgresql_iam_cluster
+          - examples/postgresql_iam_instance
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Terraform v${{ matrix.version }}
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: ${{ matrix.version }}
+
+      - name: Init & validate v${{ matrix.version }}
+        run: |
+          cd ${{ matrix.directory }}
+          terraform init
+          terraform validate
+
+      - name: tflint
+        uses: reviewdog/action-tflint@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          working_directory: ${{ matrix.directory }}
+          fail_on_error: 'true'
+          filter_mode: 'nofilter'
+          flags: '--module'
+
+  format:
+    name: Check code format
+    runs-on: ubuntu-latest
+    needs: versionExtract
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Terraform v${{ needs.versionExtract.outputs.maxVersion }}
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: ${{ needs.versionExtract.outputs.maxVersion }}
+
+      - name: Check Terraform format changes
+        run: terraform fmt --recursive -check=true


### PR DESCRIPTION
## Description
- add ci/cd github actions workflows for validating module changes and creating releases

## Motivation and Context
- ensure that changes are checked against static checks
- setup automated release process when changes are merged to `master`

## How Has This Been Tested?
- N/A - copied from `terraform-aws-datadog-forwarders`

## Screenshots (if appropriate):
