### PR TITLE
fix: Disable endpoint creation when setting `create_proxy = false`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.68.1
+    rev: v1.74.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/examples/mysql_iam_cluster/main.tf
+++ b/examples/mysql_iam_cluster/main.tf
@@ -47,7 +47,7 @@ module "rds_proxy" {
   }
 
   secrets = {
-    "${local.db_username}" = {
+    (local.db_username) = {
       description = aws_secretsmanager_secret.superuser.description
       arn         = aws_secretsmanager_secret.superuser.arn
       kms_key_id  = aws_secretsmanager_secret.superuser.kms_key_id

--- a/examples/mysql_iam_instance/main.tf
+++ b/examples/mysql_iam_instance/main.tf
@@ -47,7 +47,7 @@ module "rds_proxy" {
   }
 
   secrets = {
-    "${local.db_username}" = {
+    (local.db_username) = {
       description = aws_secretsmanager_secret.superuser.description
       arn         = aws_secretsmanager_secret.superuser.arn
       kms_key_id  = aws_secretsmanager_secret.superuser.kms_key_id

--- a/examples/postgresql_iam_cluster/main.tf
+++ b/examples/postgresql_iam_cluster/main.tf
@@ -47,7 +47,7 @@ module "rds_proxy" {
   }
 
   secrets = {
-    "${local.db_username}" = {
+    (local.db_username) = {
       description = aws_secretsmanager_secret.superuser.description
       arn         = aws_secretsmanager_secret.superuser.arn
       kms_key_id  = aws_secretsmanager_secret.superuser.kms_key_id

--- a/examples/postgresql_iam_instance/main.tf
+++ b/examples/postgresql_iam_instance/main.tf
@@ -47,7 +47,7 @@ module "rds_proxy" {
   }
 
   secrets = {
-    "${local.db_username}" = {
+    (local.db_username) = {
       description = aws_secretsmanager_secret.superuser.description
       arn         = aws_secretsmanager_secret.superuser.arn
       kms_key_id  = aws_secretsmanager_secret.superuser.kms_key_id

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,8 @@
 locals {
-  role_arn    = var.create_proxy && var.create_iam_role ? aws_iam_role.this[0].arn : var.role_arn
-  role_name   = coalesce(var.iam_role_name, var.name)
-  policy_name = coalesce(var.iam_policy_name, var.name)
+  role_arn           = var.create_proxy && var.create_iam_role ? aws_iam_role.this[0].arn : var.role_arn
+  role_name          = coalesce(var.iam_role_name, var.name)
+  policy_name        = coalesce(var.iam_policy_name, var.name)
+  db_proxy_endpoints = var.create_proxy ? var.db_proxy_endpoints : {}
 }
 
 data "aws_region" "current" {}
@@ -68,7 +69,7 @@ resource "aws_db_proxy_target" "db_cluster" {
 }
 
 resource "aws_db_proxy_endpoint" "this" {
-  for_each = var.db_proxy_endpoints
+  for_each = local.db_proxy_endpoints
 
   db_proxy_name          = aws_db_proxy.this[0].name
   db_proxy_endpoint_name = each.value.name

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,7 @@
 locals {
-  role_arn           = var.create_proxy && var.create_iam_role ? aws_iam_role.this[0].arn : var.role_arn
-  role_name          = coalesce(var.iam_role_name, var.name)
-  policy_name        = coalesce(var.iam_policy_name, var.name)
-  db_proxy_endpoints = var.create_proxy ? var.db_proxy_endpoints : {}
+  role_arn    = var.create_proxy && var.create_iam_role ? aws_iam_role.this[0].arn : var.role_arn
+  role_name   = coalesce(var.iam_role_name, var.name)
+  policy_name = coalesce(var.iam_policy_name, var.name)
 }
 
 data "aws_region" "current" {}
@@ -69,7 +68,7 @@ resource "aws_db_proxy_target" "db_cluster" {
 }
 
 resource "aws_db_proxy_endpoint" "this" {
-  for_each = local.db_proxy_endpoints
+  for_each = { for k, v in var.db_proxy_endpoints : k => v if var.create_proxy }
 
   db_proxy_name          = aws_db_proxy.this[0].name
   db_proxy_endpoint_name = each.value.name


### PR DESCRIPTION
Spotted this issue whilst trying to integrate this module into some existing code where we don't always want to create a RDS Proxy instance, but when we are creating a proxy we want a default set of endpoints.

Setting `create_proxy = false` works for the majority of resources, however the `aws_db_proxy_endpoint` resource uses a `for_each` which will try and create endpoints against a non-existent DB proxy.

~~So switch to using a `local` which gets set to an empty map if `var.create_proxy` is false.~~
In order to fix this, add a conditional to the `for_each` statement.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
