### PR TITLE
feat: Add CloudWatch log group name to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ No modules.
 | <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | IAM role name |
 | <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
 | <a name="output_log_group_arn"></a> [log\_group\_arn](#output\_log\_group\_arn) | The Amazon Resource Name (ARN) of the CloudWatch log group |
+| <a name="output_log_group_name"></a> [log\_group\_name](#output\_log\_group\_name) | The name of the CloudWatch log group |
 | <a name="output_proxy_arn"></a> [proxy\_arn](#output\_proxy\_arn) | The Amazon Resource Name (ARN) for the proxy |
 | <a name="output_proxy_default_target_group_arn"></a> [proxy\_default\_target\_group\_arn](#output\_proxy\_default\_target\_group\_arn) | The Amazon Resource Name (ARN) for the default target group |
 | <a name="output_proxy_default_target_group_id"></a> [proxy\_default\_target\_group\_id](#output\_proxy\_default\_target\_group\_id) | The ID for the default target group |

--- a/examples/mysql-iam-cluster/README.md
+++ b/examples/mysql-iam-cluster/README.md
@@ -64,6 +64,7 @@ No inputs.
 |------|-------------|
 | <a name="output_db_proxy_endpoints"></a> [db\_proxy\_endpoints](#output\_db\_proxy\_endpoints) | Array containing the full resource object and attributes for all DB proxy endpoints created |
 | <a name="output_log_group_arn"></a> [log\_group\_arn](#output\_log\_group\_arn) | The Amazon Resource Name (ARN) of the CloudWatch log group |
+| <a name="output_log_group_name"></a> [log\_group\_name](#output\_log\_group\_name) | The name of the CloudWatch log group |
 | <a name="output_proxy_arn"></a> [proxy\_arn](#output\_proxy\_arn) | The Amazon Resource Name (ARN) for the proxy |
 | <a name="output_proxy_default_target_group_arn"></a> [proxy\_default\_target\_group\_arn](#output\_proxy\_default\_target\_group\_arn) | The Amazon Resource Name (ARN) for the default target group |
 | <a name="output_proxy_default_target_group_id"></a> [proxy\_default\_target\_group\_id](#output\_proxy\_default\_target\_group\_id) | The ID for the default target group |

--- a/examples/mysql-iam-cluster/outputs.tf
+++ b/examples/mysql-iam-cluster/outputs.tf
@@ -77,3 +77,8 @@ output "log_group_arn" {
   description = "The Amazon Resource Name (ARN) of the CloudWatch log group"
   value       = module.rds_proxy.log_group_arn
 }
+
+output "log_group_name" {
+  description = "The name of the CloudWatch log group"
+  value       = module.rds_proxy.log_group_name
+}

--- a/examples/mysql-iam-instance/README.md
+++ b/examples/mysql-iam-instance/README.md
@@ -72,6 +72,7 @@ No inputs.
 |------|-------------|
 | <a name="output_db_proxy_endpoints"></a> [db\_proxy\_endpoints](#output\_db\_proxy\_endpoints) | Array containing the full resource object and attributes for all DB proxy endpoints created |
 | <a name="output_log_group_arn"></a> [log\_group\_arn](#output\_log\_group\_arn) | The Amazon Resource Name (ARN) of the CloudWatch log group |
+| <a name="output_log_group_name"></a> [log\_group\_name](#output\_log\_group\_name) | The name of the CloudWatch log group |
 | <a name="output_proxy_arn"></a> [proxy\_arn](#output\_proxy\_arn) | The Amazon Resource Name (ARN) for the proxy |
 | <a name="output_proxy_default_target_group_arn"></a> [proxy\_default\_target\_group\_arn](#output\_proxy\_default\_target\_group\_arn) | The Amazon Resource Name (ARN) for the default target group |
 | <a name="output_proxy_default_target_group_id"></a> [proxy\_default\_target\_group\_id](#output\_proxy\_default\_target\_group\_id) | The ID for the default target group |

--- a/examples/mysql-iam-instance/outputs.tf
+++ b/examples/mysql-iam-instance/outputs.tf
@@ -77,3 +77,8 @@ output "log_group_arn" {
   description = "The Amazon Resource Name (ARN) of the CloudWatch log group"
   value       = module.rds_proxy.log_group_arn
 }
+
+output "log_group_name" {
+  description = "The name of the CloudWatch log group"
+  value       = module.rds_proxy.log_group_name
+}

--- a/examples/postgresql-iam-cluster/README.md
+++ b/examples/postgresql-iam-cluster/README.md
@@ -67,6 +67,7 @@ No inputs.
 | <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | The name of the role proxy uses to access secrets |
 | <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Stable and unique string identifying the role proxy uses to access secrets |
 | <a name="output_log_group_arn"></a> [log\_group\_arn](#output\_log\_group\_arn) | The Amazon Resource Name (ARN) of the CloudWatch log group |
+| <a name="output_log_group_name"></a> [log\_group\_name](#output\_log\_group\_name) | The name of the CloudWatch log group |
 | <a name="output_proxy_arn"></a> [proxy\_arn](#output\_proxy\_arn) | The Amazon Resource Name (ARN) for the proxy |
 | <a name="output_proxy_default_target_group_arn"></a> [proxy\_default\_target\_group\_arn](#output\_proxy\_default\_target\_group\_arn) | The Amazon Resource Name (ARN) for the default target group |
 | <a name="output_proxy_default_target_group_id"></a> [proxy\_default\_target\_group\_id](#output\_proxy\_default\_target\_group\_id) | The ID for the default target group |

--- a/examples/postgresql-iam-cluster/outputs.tf
+++ b/examples/postgresql-iam-cluster/outputs.tf
@@ -78,6 +78,11 @@ output "log_group_arn" {
   value       = module.rds_proxy.log_group_arn
 }
 
+output "log_group_name" {
+  description = "The name of the CloudWatch log group"
+  value       = module.rds_proxy.log_group_name
+}
+
 # IAM role
 output "iam_role_arn" {
   description = "The Amazon Resource Name (ARN) specifying the role proxy uses to access secrets"

--- a/examples/postgresql-iam-instance/README.md
+++ b/examples/postgresql-iam-instance/README.md
@@ -72,6 +72,7 @@ No inputs.
 |------|-------------|
 | <a name="output_db_proxy_endpoints"></a> [db\_proxy\_endpoints](#output\_db\_proxy\_endpoints) | Array containing the full resource object and attributes for all DB proxy endpoints created |
 | <a name="output_log_group_arn"></a> [log\_group\_arn](#output\_log\_group\_arn) | The Amazon Resource Name (ARN) of the CloudWatch log group |
+| <a name="output_log_group_name"></a> [log\_group\_name](#output\_log\_group\_name) | The name of the CloudWatch log group |
 | <a name="output_proxy_arn"></a> [proxy\_arn](#output\_proxy\_arn) | The Amazon Resource Name (ARN) for the proxy |
 | <a name="output_proxy_default_target_group_arn"></a> [proxy\_default\_target\_group\_arn](#output\_proxy\_default\_target\_group\_arn) | The Amazon Resource Name (ARN) for the default target group |
 | <a name="output_proxy_default_target_group_id"></a> [proxy\_default\_target\_group\_id](#output\_proxy\_default\_target\_group\_id) | The ID for the default target group |

--- a/examples/postgresql-iam-instance/outputs.tf
+++ b/examples/postgresql-iam-instance/outputs.tf
@@ -77,3 +77,8 @@ output "log_group_arn" {
   description = "The Amazon Resource Name (ARN) of the CloudWatch log group"
   value       = module.rds_proxy.log_group_arn
 }
+
+output "log_group_name" {
+  description = "The name of the CloudWatch log group"
+  value       = module.rds_proxy.log_group_name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -78,6 +78,11 @@ output "log_group_arn" {
   value       = try(aws_cloudwatch_log_group.this[0].arn, null)
 }
 
+output "log_group_name" {
+  description = "The name of the CloudWatch log group"
+  value       = try(aws_cloudwatch_log_group.this[0].name, null)
+}
+
 # IAM role
 output "iam_role_arn" {
   description = "The Amazon Resource Name (ARN) of the IAM role that the proxy uses to access secrets in AWS Secrets Manager."


### PR DESCRIPTION
## Description
This adds a new output to the module for cloudwatch log groups

## Motivation and Context
I need to have to log group name to pass it to another module. Unfortunately, i only have the arn of the log group and the aws data source for the ressource won't allow a lookup by arn. Its easier to add the value to this module.

## Breaking Changes
Nope. Just more data in your outputs. This change should align nicely with the currently provided output in the aws-rds module :)

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
