### PR TITLE
docs: Update `debug_logging` variable description

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "auth" {
 }
 
 variable "debug_logging" {
-  description = "Whether the proxy includes detailed information about SQL statements in its logs"
+  description = "Whether the proxy includes detailed information about SQL statements in its logs. Only enable this setting for debugging and ensure proper security measures are in place to protect sensitive information in the logs. To minimize overhead, RDS Proxy automatically disables this setting 24 hours after activation. Use it temporarily to troubleshoot specific issues."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
## Description
Updating the description of the `debug_logging` variable

## Motivation and Context
Debug logs are automatically disabled after 24h. This causes Terraform drift. 
|Setting | Description|
|-- |-- |
| Activate enhanced logging | Enable this setting to troubleshoot proxy compatibility or performance issues. When enabled, RDS Proxy logs detailed performance information to help you debug SQL behavior or proxy connection performance and scalability. Only enable this setting for debugging and ensure proper security measures are in place to protect sensitive information in the logs. To minimize overhead, RDS Proxy automatically disables this setting 24 hours after activation. Use it temporarily to troubleshoot specific issues. |

[source](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-creating.html)

## How Has This Been Tested?
N/A - description update only.