### PR TITLE
fix: Correct service principal to rds.amazonaws.com (incl China)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ No modules.
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_service_principal.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/service_principal) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = ["rds.${data.aws_service_principal.rds[0].dns_suffix}"]
+      identifiers = ["rds.${data.aws_service_principal.rds[0].suffix}"]
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = ["rds.${data.aws_partition.current.dns_suffix}"]
+      identifiers = ["rds.amazonaws.com"]
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,10 @@ locals {
 
 data "aws_region" "current" {}
 data "aws_partition" "current" {}
-
+data "aws_service_principal" "rds" {
+  service_name = "rds"
+  region = data.aws_region.current.region
+}
 ################################################################################
 # RDS Proxy
 ################################################################################
@@ -111,7 +114,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = distinct(["rds.${data.aws_partition.current.dns_suffix}", "rds.amazonaws.com"])
+      identifiers = [data.aws_service_principal.rds.id]
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ locals {
 data "aws_region" "current" {}
 data "aws_partition" "current" {}
 data "aws_service_principal" "rds" {
+  count = var.create && var.create_iam_role ? 1 : 0
   service_name = "rds"
   region = data.aws_region.current.region
 }
@@ -114,7 +115,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = [data.aws_service_principal.rds.id]
+      identifiers = [data.aws_service_principal.rds[0].id]
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ data "aws_service_principal" "rds" {
   count = var.create && var.create_iam_role ? 1 : 0
 
   service_name = "rds"
-  region      = data.aws_region.current.name
+  region       = data.aws_region.current.name
 }
 ################################################################################
 # RDS Proxy

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = [data.aws_service_principal.rds[0].id]
+      identifiers = ["rds.${data.aws_service_principal.rds[0].dns_suffix}"]
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = ["rds.amazonaws.com"]
+      identifiers = distinct(["rds.${data.aws_partition.current.dns_suffix}", "rds.amazonaws.com"])
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ data "aws_partition" "current" {}
 data "aws_service_principal" "rds" {
   count = var.create && var.create_iam_role ? 1 : 0
   service_name = "rds"
-  region = data.aws_region.current.region
+  region = data.aws_region.current.name
 }
 ################################################################################
 # RDS Proxy

--- a/main.tf
+++ b/main.tf
@@ -8,8 +8,9 @@ data "aws_region" "current" {}
 data "aws_partition" "current" {}
 data "aws_service_principal" "rds" {
   count = var.create && var.create_iam_role ? 1 : 0
+
   service_name = "rds"
-  region = data.aws_region.current.name
+  region      = data.aws_region.current.name
 }
 ################################################################################
 # RDS Proxy

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = ["rds.${data.aws_service_principal.rds[0].suffix}"]
+      identifiers = [data.aws_service_principal.rds[0].name]
     }
   }
 }


### PR DESCRIPTION
…sal across partitions.

## Description
<!--- Describe your changes in detail -->
according to this nice gentelmen [list](https://github.com/henrysher/aws-china-iam-service-principal-list) i was able to find that rds service principal for china is the same as for commertial region (not sure about AWS gov tho)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
policy simply not work in China because service pricipal is incorrect.
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
I think not since this part was unusable in China anyway. 
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
