### PR TITLE
fix(data.aws_region): argument name is deprecated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ data "aws_service_principal" "rds" {
   count = var.create && var.create_iam_role ? 1 : 0
 
   service_name = "rds"
-  region       = data.aws_region.current.name
+  region       = data.aws_region.current.region
 }
 ################################################################################
 # RDS Proxy
@@ -153,7 +153,7 @@ data "aws_iam_policy_document" "this" {
       test     = "StringEquals"
       variable = "kms:ViaService"
       values = [
-        "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+        "secretsmanager.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
       ]
     }
   }


### PR DESCRIPTION
## Description

Argument "name" is deprecated
https://registry.terraform.io/providers/hashicorp/aws/6.13.0/docs/data-sources/region

Current status:
<img width="911" height="269" alt="image" src="https://github.com/user-attachments/assets/57c36422-7823-4782-8cee-7c981c5fa480" />

Solution:
<img width="681" height="334" alt="image" src="https://github.com/user-attachments/assets/9ea0fb80-a7c8-40bf-abb3-c11cbdff8682" />

Maybe we should bump to version 6.x and create a BC ?

