### PR TITLE
feat: Support `default_auth_scheme`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
 
 ## Modules
 
@@ -105,6 +105,7 @@ No modules.
 | <a name="input_db_cluster_identifier"></a> [db\_cluster\_identifier](#input\_db\_cluster\_identifier) | DB cluster identifier | `string` | `""` | no |
 | <a name="input_db_instance_identifier"></a> [db\_instance\_identifier](#input\_db\_instance\_identifier) | DB instance identifier | `string` | `""` | no |
 | <a name="input_debug_logging"></a> [debug\_logging](#input\_debug\_logging) | Whether the proxy includes detailed information about SQL statements in its logs | `bool` | `false` | no |
+| <a name="input_default_auth_scheme"></a> [default\_auth\_scheme](#input\_default\_auth\_scheme) | Default authentication scheme that the proxy uses for client connections to the proxy and connections from the proxy to the underlying database. Valid values are NONE and IAM\_AUTH. Defaults to NONE | `string` | `null` | no |
 | <a name="input_endpoints"></a> [endpoints](#input\_endpoints) | Map of DB proxy endpoints to create and their attributes | <pre>map(object({<br/>    name                   = optional(string)<br/>    vpc_subnet_ids         = list(string)<br/>    vpc_security_group_ids = optional(list(string))<br/>    target_role            = optional(string)<br/>    tags                   = optional(map(string), {})<br/>  }))</pre> | `{}` | no |
 | <a name="input_engine_family"></a> [engine\_family](#input\_engine\_family) | The kind of database engine that the proxy will connect to. Valid values are `MYSQL` or `POSTGRESQL` | `string` | `""` | no |
 | <a name="input_iam_policy_name"></a> [iam\_policy\_name](#input\_iam\_policy\_name) | The name of the role policy. If omitted, Terraform will assign a random, unique name | `string` | `""` | no |

--- a/examples/mysql-iam-cluster/README.md
+++ b/examples/mysql-iam-cluster/README.md
@@ -31,13 +31,13 @@ An EC2 instance configuration has been provided for use in validating the exampl
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
 
 ## Modules
 

--- a/examples/mysql-iam-cluster/versions.tf
+++ b/examples/mysql-iam-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0"
+      version = ">= 6.15"
     }
   }
 }

--- a/examples/mysql-iam-instance/README.md
+++ b/examples/mysql-iam-instance/README.md
@@ -31,14 +31,14 @@ An EC2 instance configuration has been provided for use in validating the exampl
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/mysql-iam-instance/versions.tf
+++ b/examples/mysql-iam-instance/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0"
+      version = ">= 6.15"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/postgresql-iam-cluster/README.md
+++ b/examples/postgresql-iam-cluster/README.md
@@ -31,13 +31,13 @@ An EC2 instance configuration has been provided for use in validating the exampl
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
 
 ## Modules
 

--- a/examples/postgresql-iam-cluster/main.tf
+++ b/examples/postgresql-iam-cluster/main.tf
@@ -88,7 +88,7 @@ module "rds" {
 
   name            = local.name
   engine          = "aurora-postgresql"
-  engine_version  = "14.7"
+  engine_version  = "17.5"
   master_username = "root"
 
   # When using RDS Proxy w/ IAM auth - Database must be username/password auth, not IAM

--- a/examples/postgresql-iam-cluster/versions.tf
+++ b/examples/postgresql-iam-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0"
+      version = ">= 6.15"
     }
   }
 }

--- a/examples/postgresql-iam-instance/README.md
+++ b/examples/postgresql-iam-instance/README.md
@@ -31,14 +31,14 @@ An EC2 instance configuration has been provided for use in validating the exampl
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/postgresql-iam-instance/versions.tf
+++ b/examples/postgresql-iam-instance/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0"
+      version = ">= 6.15"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ resource "aws_db_proxy" "this" {
   }
 
   debug_logging          = var.debug_logging
+  default_auth_scheme    = var.default_auth_scheme
   engine_family          = var.engine_family
   idle_client_timeout    = var.idle_client_timeout
   name                   = var.name

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,12 @@ variable "debug_logging" {
   default     = false
 }
 
+variable "default_auth_scheme" {
+  description = "Default authentication scheme that the proxy uses for client connections to the proxy and connections from the proxy to the underlying database. Valid values are NONE and IAM_AUTH. Defaults to NONE"
+  type        = string
+  default     = null
+}
+
 variable "engine_family" {
   description = "The kind of database engine that the proxy will connect to. Valid values are `MYSQL` or `POSTGRESQL`"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0"
+      version = ">= 6.15"
     }
   }
 }

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -15,6 +15,7 @@ module "wrapper" {
   db_cluster_identifier          = try(each.value.db_cluster_identifier, var.defaults.db_cluster_identifier, "")
   db_instance_identifier         = try(each.value.db_instance_identifier, var.defaults.db_instance_identifier, "")
   debug_logging                  = try(each.value.debug_logging, var.defaults.debug_logging, false)
+  default_auth_scheme            = try(each.value.default_auth_scheme, var.defaults.default_auth_scheme, null)
   endpoints                      = try(each.value.endpoints, var.defaults.endpoints, {})
   engine_family                  = try(each.value.engine_family, var.defaults.engine_family, "")
   iam_policy_name                = try(each.value.iam_policy_name, var.defaults.iam_policy_name, "")

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0"
+      version = ">= 6.15"
     }
   }
 }


### PR DESCRIPTION
## Description
Support `default_auth_scheme` for rds proxy. 

## Motivation and Context
- https://github.com/hashicorp/terraform-provider-aws/pull/44309
- https://aws.amazon.com/about-aws/whats-new/2025/09/amazon-rds-proxy-end-to-end-iam-authentication/

## Breaking Changes
No. 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
