### PR TITLE
fix: Recreate custom endpoints when the proxy is replaced

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,6 +97,15 @@ resource "aws_db_proxy_endpoint" "this" {
   target_role            = each.value.target_role
 
   tags = merge(var.tags, each.value.tags)
+
+  # A custom endpoint references its proxy by name (stable), so a ForceNew on the
+  # proxy (e.g. an endpoint_network_type / target_connection_network_type change)
+  # replaces the proxy but leaves this endpoint behind, orphaning it. Tie the
+  # endpoint's lifecycle to the proxy so it is destroyed before the proxy and
+  # recreated after it.
+  lifecycle {
+    replace_triggered_by = [aws_db_proxy.this[0]]
+  }
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -102,9 +102,10 @@ resource "aws_db_proxy_endpoint" "this" {
   # proxy (e.g. an endpoint_network_type / target_connection_network_type change)
   # replaces the proxy but leaves this endpoint behind, orphaning it. Tie the
   # endpoint's lifecycle to the proxy so it is destroyed before the proxy and
-  # recreated after it.
+  # recreated after it. Trigger on the ARN (new prx- id on every recreation), not
+  # the whole resource: in-place proxy updates must not replace live endpoints.
   lifecycle {
-    replace_triggered_by = [aws_db_proxy.this[0]]
+    replace_triggered_by = [aws_db_proxy.this[0].arn]
   }
 }
 


### PR DESCRIPTION
**Description**
Add `replace_triggered_by = [aws_db_proxy.this[0]]` to the `aws_db_proxy_endpoint.this` resource so custom endpoints are recreated together with the proxy when it is replaced.

**Motivation and Context**
A custom `aws_db_proxy_endpoint` references its proxy by name, which is stable. When the proxy is replaced (ForceNew — e.g. changing `endpoint_network_type` or `target_connection_network_type` for IPv6/dual-stack), Terraform leaves the custom endpoints attached to the old, now-destroyed proxy and does not recreate them, orphaning them. Binding the endpoint lifecycle to the proxy destroys it before the proxy and recreates it after.

**Breaking Changes**
None. No new inputs/outputs; behaviour only changes on a proxy replacement, which already disrupts the custom endpoints.

**How Has This Been Tested?**
- [x] Plan against a proxy with custom rw/ro endpoints + a network-type change: the endpoints now show replace (with the proxy) instead of being orphaned.